### PR TITLE
Allow test methods created from data sets to be decorated individually

### DIFF
--- a/cafe/drivers/unittest/datasets.py
+++ b/cafe/drivers/unittest/datasets.py
@@ -57,7 +57,13 @@ class DatasetList(list):
         super(DatasetList, self).append(dataset)
 
     def append_new_dataset(self, name, data_dict, tags=None, decorators=None):
-        """Creates and appends a new Dataset"""
+        """Creates and appends a new Dataset
+
+        When including a `decorators` value (a list), make sure that the
+        functions provided in the list are provided in the order in which
+        they should be executed. When comparing them to typical stacked
+        decorators, order them from bottom to top.
+        """
         self.append(_Dataset(name, data_dict, tags, decorators))
 
     def extend(self, dataset_list):

--- a/cafe/drivers/unittest/datasets.py
+++ b/cafe/drivers/unittest/datasets.py
@@ -26,14 +26,20 @@ class _Dataset(object):
     name should be a string describing the dataset.
     This class should not be accessed directly. Use or extend DatasetList.
     """
-    def __init__(self, name, data_dict, tags=None):
+    def __init__(self, name, data_dict, tags=None, decorators=None):
         self.name = name
         self.data = data_dict
-        self.metadata = {'tags': tags or []}
+        self.metadata = {
+            'tags': tags or [],
+            'decorators': decorators or []
+        }
 
     def apply_test_tags(self, tags):
         self.metadata['tags'] = list(
             set(self.metadata.get('tags')).union(set(tags)))
+
+    def apply_test_decorators(self, decorators):
+        self.metadata['decorators'] += list(decorators)
 
     def __repr__(self):
         return "<name:{0}, data:{1}>".format(self.name, self.data)
@@ -50,9 +56,9 @@ class DatasetList(list):
 
         super(DatasetList, self).append(dataset)
 
-    def append_new_dataset(self, name, data_dict, tags=None):
+    def append_new_dataset(self, name, data_dict, tags=None, decorators=None):
         """Creates and appends a new Dataset"""
-        self.append(_Dataset(name, data_dict, tags))
+        self.append(_Dataset(name, data_dict, tags, decorators))
 
     def extend(self, dataset_list):
         if not isinstance(dataset_list, DatasetList):
@@ -66,9 +72,14 @@ class DatasetList(list):
         self.extend(dataset_list)
 
     def apply_test_tags(self, *tags):
-        """Applys tags to all tests in dataset list"""
+        """Applies tags to all tests in dataset list"""
         for dataset in self:
             dataset.apply_test_tags(tags)
+
+    def apply_test_decorators(self, *decorators):
+        """Applies decorators to all tests in dataset list"""
+        for dataset in self:
+            dataset.apply_test_decorators(decorators)
 
     def dataset_names(self):
         """Gets a list of dataset names from dataset list"""

--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -229,6 +229,9 @@ def DataDrivenFixture(cls):
                 new_test, dataset.metadata.get('tags', []),
                 PARALLEL_TAGS_LIST_ATTR)
 
+            for decorator in dataset.metadata.get('decorators', []):
+                new_test = decorator(new_test)
+
             # Add the new test to the decorated TestCase
             setattr(cls, new_test_name, new_test)
     return cls

--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -229,6 +229,7 @@ def DataDrivenFixture(cls):
                 new_test, dataset.metadata.get('tags', []),
                 PARALLEL_TAGS_LIST_ATTR)
 
+            # Apply decorators to the new test
             for decorator in dataset.metadata.get('decorators', []):
                 new_test = decorator(new_test)
 


### PR DESCRIPTION
This PR is opened on my local fork, just to get some preliminary feedback as to whether or not this is what we are looking for in preparation for test coverage metrics using OpenCafe.

### The Idea
The idea behind this PR is be able to treat test methods generated by the `DataDrivenFixture` decorator as any other test method, i.e. being able to add specific decorators to that test method.

This will allow for greater flexibility when working with data driven sets. For more specific context, I use decorators to control the current state of a test. For example, I have a `@needs_work` decorator that signifies that the test is not working properly because I need to tweak the test. In this decorator, the test is skipped and the "needs_work" tag is added to the other test tags, among other things.

Currently, I cannot label individual data sets with this kind of tag. I can only apply it to the entire `ddtest` method that is manually written.

### The Solution This PR Proposes
This is an example of what an implementation using the changes in this PR would look like.
```py
from cafe.drivers.unittest.datasets import DatasetList
from cafe.drivers.unittest.decorators import data_driven_test, DataDrivenFixture
from cafe.drivers.unittest.fixtures import BaseTestFixture
from my_decorators import needs_work


example_datasets = DatasetList()
example_datasets.append_new_dataset(
    "example_test_name_1",
    data_dict={
        "key": "value"
    },
    tags=["positive", "smoke"]
)
example_datasets.append_new_dataset(
    "example_test_name_2",
    data_dict={
        "key": "value"
    },
    decorators=[needs_work("JIRA-123")]
    tags=["positive", "smoke"]
)


@DataDrivenFixture
class ExampleTests(BaseTestFixture):

    @data_driven_test(example_data_sets)
    def ddtest_example(self, key)
        pass

```
If I run the `ddtest` in the example, it will be the equivalent to manually writing this:
```py
class ExampleTests(BaseTestFixture):

    @tags("positive", "smoke")
    def test_example_example_test_name_1(self)
        pass

    @tags("positive", "smoke")
    @needs_work("JIRA-123")
    def test_example_example_test_name_2(self)
        pass
```
which is what I am looking to for.